### PR TITLE
BMI result now easier to read and understand by rounding to 2 decimal…

### DIFF
--- a/src/components/BmiResult.tsx
+++ b/src/components/BmiResult.tsx
@@ -7,7 +7,7 @@ const BmiResult: React.FC<{BmiResult: number}> = props => {
 			<IonCol>
 				<IonCard>
 					<IonCardContent>
-						<h2>{props.BmiResult}</h2>
+						<h2>{props.BmiResult.toFixed(2)}</h2>
 					</IonCardContent>
 				</IonCard>
 			</IonCol>


### PR DESCRIPTION
The BMI result is now easier to read and understand as it is rounded down to 2 decimal places.

Closes #17 